### PR TITLE
Refactor concurrent stack

### DIFF
--- a/src/docs/ConcurrentStack.md
+++ b/src/docs/ConcurrentStack.md
@@ -1,6 +1,6 @@
     ConcurrentStack{T}()
 
-Concurrent stack of objects of type `T`.
+Treiber's concurrent stack of objects of type `T`.
 
 Use `push!` to insert an element and [`maybepop!`](@ref) to retrieve and remove an
 element.

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -1,6 +1,6 @@
 mutable struct TSNode{T}
     value::T
-    @atomic next::Union{TSNode{T},Nothing}
+    next::Union{TSNode{T},Nothing}
 end
 
 TSNode{T}(value::T) where {T} = TSNode{T}(value, nothing)
@@ -17,7 +17,7 @@ function Base.push!(stack::ConcurrentStack{T}, v) where {T}
 
     next = @atomic stack.next
     while true
-        @atomic node.next = next
+        node.next = next
         next, ok = @atomicreplace(stack.next, next => node)
         ok && break
     end
@@ -30,7 +30,7 @@ function ConcurrentCollections.maybepop!(stack::ConcurrentStack)
         node = @atomic stack.next
         node === nothing && return nothing
 
-        next = @atomic node.next
+        next = node.next
         next, ok = @atomicreplace(stack.next, node => next)
         if ok
             return Some(node.value)


### PR DESCRIPTION
I revise concurrent stack implement by refering the `crossbeam` implmentation and [Jeehoon Kang's implementation](https://github.com/kaist-cp/cs431/blob/main/src/lockfree/stack.rs) by Rust.

1. Rename and reposition struct's paramter for readability and consistency
2. Specify the ordering of atomic operations
3. Remove `@atomic` macro in node's parameter.

I specified ordering with the help of  `crossbeam` implementation. Additionally, nodes in the concurrent stack do not need to have atomic pointer because the pointers does not change while they are in the stack (immutable when in shared memory). I take a hint from Jeehoon Kang's code.

It passes test in my machine:

- Julia version:  1.8.5
- CPU: i5-12600KF
- thread: 16